### PR TITLE
add SymPy support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN adduser --shell /bin/bash --gecos "" --disabled-password --home /home/oscar 
 USER oscar
 WORKDIR /home/oscar
 
-RUN julia -e 'using Pkg; pkg" add Oscar; add IJulia; precompile "; using Oscar'
+RUN julia -e 'using Pkg; pkg" add Oscar; add IJulia; add SymPy; precompile "; using Oscar'
 
 RUN mkdir -p ~/.julia/config
 RUN echo 'println("Welcome! Type \"using Oscar\" to start...")' > ~/.julia/config/startup.jl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM julia:buster
 
 RUN apt update
-RUN apt install -y --no-install-recommends build-essential m4 python3 python3-pip python3-setuptools git wget 
+RUN apt install -y --no-install-recommends build-essential m4 python3 python3-dev python3-pip python3-setuptools git wget 
 
 RUN pip3 install wheel
 RUN pip3 install jupyterlab
+RUN pip3 install sympy
 
 RUN adduser --shell /bin/bash --gecos "" --disabled-password --home /home/oscar oscar
 USER oscar


### PR DESCRIPTION
This PR adds python3-dev headers needed for PyCall.jl (the julia wrapper for python packages) and preinstalls SymPy for use in the [PBWDeformations.jl](https://gitlab.com/a-rt/pbwdeformations.jl) package and test-suite.